### PR TITLE
feat: add department filter to employees table

### DIFF
--- a/src/features/employees/presentation/pages/EmployeesPage.tsx
+++ b/src/features/employees/presentation/pages/EmployeesPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useGetEmployeesQuery } from "../../data/employeesApi";
+import { useGetEmployeesQuery, useGetDepartmentsQuery } from "../../data/employeesApi";
 import { EmployeesTable } from "../components/EmployeesTable";
 import { EmployeeCreateForm } from "../components/EmployeeCreateForm";
 import { Modal } from "../../../../shared/components/Modal";
@@ -10,7 +10,9 @@ interface Props {
 
 export function EmployeesPage({ onEmployeeClick }: Props) {
   const { data: employees, isLoading, isError } = useGetEmployeesQuery();
+  const { data: departments } = useGetDepartmentsQuery();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedDepartment, setSelectedDepartment] = useState("All");
 
   if (isLoading) {
     return <p className="p-8 text-gray-500">Loading employees...</p>;
@@ -24,18 +26,37 @@ export function EmployeesPage({ onEmployeeClick }: Props) {
     );
   }
 
+  const filteredEmployees =
+    selectedDepartment === "All"
+      ? (employees ?? [])
+      : (employees ?? []).filter((e) => e.department === selectedDepartment);
+
   return (
     <div className="p-8">
       <div className="mb-6 flex items-center justify-between">
         <h2 className="text-xl font-semibold text-gray-800">Employees</h2>
-        <button
-          onClick={() => setIsModalOpen(true)}
-          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-        >
-          + Add Employee
-        </button>
+        <div className="flex items-center gap-3">
+          <select
+            value={selectedDepartment}
+            onChange={(e) => setSelectedDepartment(e.target.value)}
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          >
+            <option value="All">All Departments</option>
+            {departments?.map((dept) => (
+              <option key={dept.id} value={dept.name}>
+                {dept.name}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={() => setIsModalOpen(true)}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          >
+            + Add Employee
+          </button>
+        </div>
       </div>
-      <EmployeesTable employees={employees ?? []} onRowClick={onEmployeeClick} />
+      <EmployeesTable employees={filteredEmployees} onRowClick={onEmployeeClick} />
       {isModalOpen && (
         <Modal title="New Employee" onClose={() => setIsModalOpen(false)}>
           <EmployeeCreateForm onSuccess={() => setIsModalOpen(false)} />


### PR DESCRIPTION
## Summary

Closes #1

- Adds a department dropdown above the employees table using the existing `useGetDepartmentsQuery` hook
- Selecting a department filters the table rows in real-time
- Defaults to "All Departments" showing all employees

## Test plan

- [ ] Start both dev server (`npm run dev`) and mock API (`npm run mock`)
- [ ] Navigate to the employees page — dropdown shows "All Departments" and all rows are visible
- [ ] Select a department — only employees from that department appear
- [ ] Select "All Departments" again — all employees are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)