### PR TITLE
feat: add real-time employee name search

### DIFF
--- a/src/features/employees/data/employeesApi.ts
+++ b/src/features/employees/data/employeesApi.ts
@@ -1,10 +1,7 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { baseApi } from "../../../store/baseApi";
 import type { Employee, Department } from "../domain/employee.types";
 
-export const employeesApi = createApi({
-  reducerPath: "employeesApi",
-  baseQuery: fetchBaseQuery({ baseUrl: "http://localhost:3001" }),
-  tagTypes: ["Employees"],
+export const employeesApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     getEmployees: builder.query<Employee[], void>({
       query: () => "/employees",
@@ -18,6 +15,7 @@ export const employeesApi = createApi({
     }),
     getDepartments: builder.query<Department[], void>({
       query: () => "/departments",
+      providesTags: ["Departments"],
     }),
     addEmployee: builder.mutation<Employee, Omit<Employee, "id">>({
       query: (body) => ({

--- a/src/features/employees/presentation/components/EmployeeCreateForm.tsx
+++ b/src/features/employees/presentation/components/EmployeeCreateForm.tsx
@@ -1,8 +1,7 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { useAddEmployeeMutation } from "../../data/employeesApi";
-import { useGetDepartmentsQuery } from "../../data/employeesApi";
+import { useAddEmployeeMutation, useGetDepartmentsQuery } from "../../data/employeesApi";
 
 const schema = z.object({
   firstName: z.string().min(2, "First name must be at least 2 characters"),
@@ -33,6 +32,7 @@ export function EmployeeCreateForm({ onSuccess }: Props) {
     register,
     handleSubmit,
     reset,
+    setError,
     formState: { errors },
   } = useForm<EmployeeCreateFormValues>({
     resolver: zodResolver(schema),
@@ -40,9 +40,13 @@ export function EmployeeCreateForm({ onSuccess }: Props) {
   });
 
   const onSubmit = async (values: EmployeeCreateFormValues) => {
-    await addEmployee(values).unwrap();
-    reset();
-    onSuccess?.();
+    try {
+      await addEmployee(values).unwrap();
+      reset();
+      onSuccess?.();
+    } catch {
+      setError("root", { message: "Failed to create employee. Please try again." });
+    }
   };
 
   return (
@@ -140,6 +144,10 @@ export function EmployeeCreateForm({ onSuccess }: Props) {
         </label>
         <input {...register("phone")} type="tel" className={INPUT_CLASS} />
       </div>
+
+      {errors.root && (
+        <p className="text-sm text-red-500">{errors.root.message}</p>
+      )}
 
       <div className="flex justify-end pt-2">
         <button

--- a/src/features/employees/presentation/pages/EmployeesPage.tsx
+++ b/src/features/employees/presentation/pages/EmployeesPage.tsx
@@ -13,6 +13,7 @@ export function EmployeesPage({ onEmployeeClick }: Props) {
   const { data: departments } = useGetDepartmentsQuery();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedDepartment, setSelectedDepartment] = useState("All");
+  const [searchQuery, setSearchQuery] = useState("");
 
   if (isLoading) {
     return <p className="p-8 text-gray-500">Loading employees...</p>;
@@ -26,16 +27,31 @@ export function EmployeesPage({ onEmployeeClick }: Props) {
     );
   }
 
-  const filteredEmployees =
-    selectedDepartment === "All"
-      ? (employees ?? [])
-      : (employees ?? []).filter((e) => e.department === selectedDepartment);
+  const filteredEmployees = (employees ?? [])
+    .filter((e) =>
+      selectedDepartment === "All" ? true : e.department === selectedDepartment,
+    )
+    .filter((e) => {
+      const q = searchQuery.trim().toLowerCase();
+      if (!q) return true;
+      return (
+        e.firstName.toLowerCase().includes(q) ||
+        e.lastName.toLowerCase().includes(q)
+      );
+    });
 
   return (
     <div className="p-8">
       <div className="mb-6 flex items-center justify-between">
         <h2 className="text-xl font-semibold text-gray-800">Employees</h2>
         <div className="flex items-center gap-3">
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search by name..."
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
           <select
             value={selectedDepartment}
             onChange={(e) => setSelectedDepartment(e.target.value)}

--- a/src/features/employees/presentation/pages/EmployeesPage.tsx
+++ b/src/features/employees/presentation/pages/EmployeesPage.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export function EmployeesPage({ onEmployeeClick }: Props) {
   const { data: employees, isLoading, isError } = useGetEmployeesQuery();
-  const { data: departments } = useGetDepartmentsQuery();
+  const { data: departments, isError: isDepartmentsError } = useGetDepartmentsQuery();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedDepartment, setSelectedDepartment] = useState("All");
   const [searchQuery, setSearchQuery] = useState("");
@@ -58,11 +58,15 @@ export function EmployeesPage({ onEmployeeClick }: Props) {
             className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           >
             <option value="All">All Departments</option>
-            {departments?.map((dept) => (
-              <option key={dept.id} value={dept.name}>
-                {dept.name}
-              </option>
-            ))}
+            {isDepartmentsError ? (
+              <option disabled>Failed to load departments</option>
+            ) : (
+              departments?.map((dept) => (
+                <option key={dept.id} value={dept.name}>
+                  {dept.name}
+                </option>
+              ))
+            )}
           </select>
           <button
             onClick={() => setIsModalOpen(true)}

--- a/src/store/baseApi.ts
+++ b/src/store/baseApi.ts
@@ -1,0 +1,8 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const baseApi = createApi({
+  reducerPath: "api",
+  baseQuery: fetchBaseQuery({ baseUrl: "http://localhost:3001" }),
+  tagTypes: ["Employees", "Departments"],
+  endpoints: () => ({}),
+});

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,15 +1,15 @@
 import { configureStore } from "@reduxjs/toolkit";
-import { employeesApi } from "../features/employees/data/employeesApi";
+import { baseApi } from "./baseApi";
 import { employeeDetailApi } from "../features/employee-detail/data/employeeDetailApi";
 
 export const store = configureStore({
   reducer: {
-    [employeesApi.reducerPath]: employeesApi.reducer,
+    [baseApi.reducerPath]: baseApi.reducer,
     [employeeDetailApi.reducerPath]: employeeDetailApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware()
-      .concat(employeesApi.middleware)
+      .concat(baseApi.middleware)
       .concat(employeeDetailApi.middleware),
 });
 


### PR DESCRIPTION
CHL-1 Completed

## Summary

- Adds a real-time search input above the employees table that filters by first or last name (case-insensitive)
- Composes with the existing department filter
- Fixes all code quality issues identified in review: central `baseApi`, `providesTags` on `getDepartments`, `onSubmit` error handling, duplicate imports, and departments error state

## Test plan

- [ ] Type in the search box — table filters in real-time by first or last name
- [ ] Search is case-insensitive
- [ ] Clearing the input restores all employees
- [ ] Search and department filter work together
- [ ] Creating an employee with the mock server down shows an error message in the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)